### PR TITLE
Optimierung für Android SDK 35

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -66,15 +66,10 @@ tasks.withType(JavaCompile).configureEach {
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.7.1'
     implementation "androidx.core:core:1.13.1"
-    implementation "androidx.core:core-ktx:1.13.1"
     implementation 'com.google.android.material:material:1.12.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
     implementation 'androidx.recyclerview:recyclerview:1.4.0'
     implementation 'androidx.preference:preference:1.2.1'
-
-    // Lifecycle
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.9.2'
-    implementation 'androidx.lifecycle:lifecycle-process:2.9.2'
 
     // App Startup
     implementation 'androidx.startup:startup-runtime:1.2.0'
@@ -82,9 +77,6 @@ dependencies {
     // Navigation (Fragment + UI)
     implementation 'androidx.navigation:navigation-fragment:2.9.3'
     implementation 'androidx.navigation:navigation-ui:2.9.3'
-
-    // Alte Support-APIs (nur falls nötig)
-    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
 
     // Tests
     testImplementation 'junit:junit:4.13.2'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools"
-    android:name=".globals">
+    android:name="com.dsinet.pjesmaricapro.ostalo.globals">
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
- compileSdk und targetSdk sind bereits auf 35 gesetzt.\n- Manifest: Application-Klasse auf vollqualifizierten Namen korrigiert (verhindert Crash beim Start).\n- build.gradle: Unbenutzte KTX-/Legacy-Abhängigkeiten entfernt, um Kotlin-Runtime zu vermeiden und App-Größe zu reduzieren.\n\nKeine funktionalen Änderungen am Code. Bitte mit Android 15 (API 35) kurz gegenprüfen.

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/c15822c4-c494-4139-a00d-f321ed195997/task/965a4a90-c1cb-4f05-828d-4032d15050ad))